### PR TITLE
[fix] Fix typos that prevented the mixer_paths.xml file to be valid XML

### DIFF
--- a/audio/mixer_paths.xml
+++ b/audio/mixer_paths.xml
@@ -49,17 +49,17 @@
     <ctl name="Voip Evrc Min Max Rate Config" id="1" value="4" />
     <ctl name="Voip Dtx Mode" value="0" />
     <ctl name="TTY Mode" value="Off" />
-    
+
     <!-- headphone volume, left/right -->
     <ctl name="HPHL Volume" value="15" />
     <ctl name="HPHR Volume" value="15" />
-    
+
     <!-- digital gains for interpolation filters RX1, RX2, RX3 -->
     <!-- 84 = 0 dB -->
     <ctl name="RX1 Digital Volume" value="84" />
     <ctl name="RX2 Digital Volume" value="84" />
     <ctl name="RX3 Digital Volume" value="84" />
-    
+
     <!-- digital gains for infinite impulse response filter  -->
     <!-- inputs. 84 = 0 dB -->
     <!-- IIR1 possible inputs are: ZERO, DEC1, DEC2, RX1, RX2, RX3 -->
@@ -67,30 +67,30 @@
     <ctl name="IIR1 INP2 Volume" value="84" />
     <ctl name="IIR1 INP3 Volume" value="84" />
     <ctl name="IIR1 INP4 Volume" value="84" />
-    
+
     <!-- analog gains for ADCs. MSM8916 has only ADC1 and ADC2 -->
     <ctl name="ADC1 Volume" value="6" />
     <ctl name="ADC2 Volume" value="6" />
     <ctl name="ADC3 Volume" value="6" />
-    
+
     <!-- digital gains for decimation filters DEC1 and DEC2 -->
     <!-- 84 = 0 dB -->
     <ctl name="DEC1 Volume" value="84" />
     <ctl name="DEC2 Volume" value="84" />
-    
+
     <!-- DEC1 and DEC2, ADC2 and RDAC1 MUXs -->
     <ctl name="DEC2 MUX" value="ZERO" />
     <ctl name="DEC1 MUX" value="ZERO" />
     <ctl name="ADC2 MUX" value="ZERO" />
     <ctl name="RDAC2 MUX" value="ZERO" />
-    
+
     <!-- Mixer2 settings. MIX2 possible inputs are:    -->
     <!-- ZERO, IIR1, IIR2. Typically used for sidetone -->
     <ctl name="RX2 MIX2 INP2" value="ZERO" />
     <ctl name="RX2 MIX2 INP1" value="ZERO" />
     <ctl name="RX1 MIX2 INP2" value="ZERO" />
     <ctl name="RX1 MIX2 INP1" value="ZERO" />
-    
+
     <!-- Mixer1 settings. MIX1 possible inputs are: -->
     <!-- ZERO, DEC1, DEC2, RX1, RX2, RX3            -->
     <!-- typically used for routing/mixing          -->
@@ -100,21 +100,21 @@
     <ctl name="RX2 MIX1 INP1" value="ZERO" />
     <ctl name="RX1 MIX1 INP2" value="ZERO" />
     <ctl name="RX1 MIX1 INP1" value="ZERO" />
-   
+
     <ctl name="EAR_S" value="ZERO" />
-    
+
     <!-- headphone channels, left/right -->
     <ctl name="HPHL" value="ZERO" />
     <ctl name="HPHR" value="ZERO" />
-    
+
     <!-- speaker settings -->
     <ctl name="SPK DAC Switch" value="0" />
     <ctl name="Speaker Boost" value="ENABLE" />
-    
+
     <!-- earpiece settings -->
     <ctl name="EAR PA Boost" value="ENABLE" />
     <ctl name="EAR PA Gain" value="POS_0_DB" />
-    
+
     <!-- I2S interfaces settings -->
     <ctl name="MI2S_RX Channels" value="One" />
     <ctl name="MI2S_TX Channels" value="One" />
@@ -571,22 +571,22 @@
     </path>
 
     <!-- These are actual sound device specific mixer settings -->
-   
+
     <path name="adc1">
     	<!-- connect DEC1 (TX1) is to ADC1 (handset mic) -->
         <ctl name="DEC1 MUX" value="ADC1" />
     </path>
 
     <path name="adc2">
-    	<!-- connect DEC1 (TX1) to ADC2 (muxed) -->	
+    	<!-- connect DEC1 (TX1) to ADC2 (muxed) -->
         <ctl name="DEC1 MUX" value="ADC2" />
     </path>
-    
+
     <!-- does INP3 exist on the trunk?    -->
     <path name="adc3">
     	<!-- connect DEC1 (TX1) to ADC2 -->
         <ctl name="DEC1 MUX" value="ADC2" />
-        <--! and ADC to INP3 -->
+        <!-- and ADC to INP3 -->
         <ctl name="ADC2 MUX" value="INP3" />
     </path>
 
@@ -641,7 +641,7 @@
     </path>
 
     <path name="headset-mic">
-    	<!-- use ADC2 --->
+    	<!-- use ADC2 -->
         <path name="adc2" />
         <!-- connect INP2 (headset mic) to ADC2 -->
         <ctl name="ADC2 MUX" value="INP2" />


### PR DESCRIPTION
Changed two typos causing audio system to fail in any audio playback. 
All other changes are just whitespaces removed by editor
